### PR TITLE
fix: added flush() for proper shutdown

### DIFF
--- a/src/framework/KafkaManager.cpp
+++ b/src/framework/KafkaManager.cpp
@@ -123,6 +123,7 @@ namespace OpenWifi {
 			}
 			Note = Queue_.waitDequeueNotification();
 		}
+		Producer.flush();
 		poco_information(Logger_, "Stopped...");
 	}
 


### PR DESCRIPTION
# Description
Need to flush Kafka messages on shutdown.

NOTE: This PR is port of https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/pull/361

https://telecominfraproject.atlassian.net/browse/WIFI-13597

# Summary of changes:
- Added flush() for proper shutdown.
