### PR TITLE
WIFI-13857: fix: modified code to use flush() when internal queue is not loaded

### DIFF
--- a/src/framework/KafkaManager.cpp
+++ b/src/framework/KafkaManager.cpp
@@ -107,7 +107,16 @@ namespace OpenWifi {
 					NewMessage.partition(0);
 					NewMessage.payload(Msg->Payload());
 					Producer.produce(NewMessage);
-					Producer.poll((std::chrono::milliseconds) 0);
+					if (Queue_.size() < 100) {
+						// use flush when internal queue is lightly loaded, i.e. flush after each
+						// message
+						Producer.flush();
+					}
+					else {
+						// use poll when internal queue is loaded to allow messages to be sent in
+						// batches
+						Producer.poll((std::chrono::milliseconds) 0);
+					}
 				}
 			} catch (const cppkafka::HandleException &E) {
 				poco_warning(Logger_,


### PR DESCRIPTION
# Description

When queue is not loaded, use of `poll()` might prevent Kafka messages to be delivered on time. This can affect Kafka registration messages. The use of `flush()` on lightly loaded queue should allow messages to be delivered.

Details in:
https://telecominfraproject.atlassian.net/browse/WIFI-13597
https://telecominfraproject.atlassian.net/browse/WIFI-13857

# Summary of changes

- Modified code to use `flush()` when internal queue is not loaded.

NOTE: This is port of https://github.com/Telecominfraproject/wlan-cloud-ucentralgw/pull/362